### PR TITLE
Merge nvdisasm parse

### DIFF
--- a/bin/gen_xlat_metadata.py
+++ b/bin/gen_xlat_metadata.py
@@ -43,12 +43,12 @@ def extract_elf(fatbin):
 
     return elf_data
 
-def get_function_info(fatbin, ptx_missing_okay = False):
+def get_function_info(fatbin, ptx_missing_okay = False, add_branch_targets = False):
     def _gfi(ocubin):
         function_info = []
 
         for elfcubin, rawelf in elf_data:
-            disfns = DisassemblerCUObjdump.disassemble(elfcubin, src = fatbin.elf)
+            disfns = DisassemblerCUObjdump.disassemble(elfcubin, src = fatbin.elf, add_branch_targets=add_branch_targets)
 
             for fn, sassfn in disfns.items():
                 function_info.append(sassfn)
@@ -146,6 +146,7 @@ if __name__ == "__main__":
     p.add_argument("--no-demangle", dest="demangle", action="store_false", help="Do not demangle function names, which uses c++filt")
     p.add_argument("--no-relocs", dest="relocs", action="store_false", help="Do not extract functions referenced in relocations even if they do not match --only")
     p.add_argument("--ptx-missing-okay", action="store_true", help="Extract ELF/SASS data even if PTX is missing.")
+    p.add_argument("--with-branch-targets", action="store_true", help="Use nvdisasm to extract branch targets.")
     p.add_argument("-r", dest="ptx_missing_okay", action="store_true", help="Executable was compiled using -rdc, extract ELF/SASS data from executable ELF (which usually contains no PTX).")
 
 
@@ -157,7 +158,7 @@ if __name__ == "__main__":
 
     fatbin = nvfatbin.NVFatBinary(args.elffile, decompressor=DefaultDecompressor)
     fatbin.parse_fatbin()
-    function_info = get_function_info(fatbin, args.ptx_missing_okay)
+    function_info = get_function_info(fatbin, args.ptx_missing_okay, args.with_branch_targets)
 
     only_re = re.compile("|".join(args.only_re))
     except_re = re.compile("|".join(args.except_re))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 pyelftools
 lz4
+PyYAML

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(name='harmonv',
       scripts=['bin/hcuobjdump',
                'bin/gen_xlat_metadata.py',
                'bin/fbextractor.py'],
-      install_requires = ['pyelftools', 'lz4']
+      install_requires = ['pyelftools', 'lz4', 'PyYAML']
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class CustomDevelop(develop):
         develop.run(self)
 
 setup(name='harmonv',
-      version='0.1',
+      version='0.2',
       packages=['harmonv'],
       cmdclass={'install': CustomInstall, 'develop': CustomDevelop},
       package_data={'harmonv': ['ptx/*.cfg', 'ptx/*.interp', 'ptx/*.tokens']},


### PR DESCRIPTION
Adds an option, ``--with-branch-targets``, to `gen_xlat_metadta.py` to enable using nvdisasm during xlat generation to get the branch targets for SYNC, PBK, and similar instructions.
Adds a new section to the per-function xlat metadata called "branch_targets" that stores the branch targets for such instructions.